### PR TITLE
Remove deprecated code

### DIFF
--- a/inc/widget/breadcrumb.php
+++ b/inc/widget/breadcrumb.php
@@ -3,9 +3,8 @@ namespace UltraAddons\Widget;
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
-use Elementor\Core\Schemes\Color;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
 use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Group_Control_Border;
 use Elementor\Group_Control_Box_Shadow;
@@ -91,9 +90,8 @@ class Breadcrumb extends Base{
             [
                 'label'     => __( 'Background', 'ultraaddons' ),
                 'type'      => Controls_Manager::COLOR,
-                'scheme'    => [
-                    'type'  => Color::get_type(),
-                    'value' => Color::COLOR_1,
+                'global' => [
+                    'default' => Global_Colors::COLOR_PRIMARY,
                 ],
                 'selectors' => [
                     '{{WRAPPER}} .ultraaddons-breadcrumb' => 'background-color: {{VALUE}}',

--- a/inc/widget/post-title.php
+++ b/inc/widget/post-title.php
@@ -3,9 +3,8 @@ namespace UltraAddons\Widget;
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
-use Elementor\Core\Schemes\Color;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
 use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Group_Control_Border;
 use Elementor\Group_Control_Box_Shadow;
@@ -143,10 +142,9 @@ class Post_Title extends Base{
             [
                 'label'     => __( 'Color', 'ultraaddons' ),
                 'type'      => Controls_Manager::COLOR,
-                'scheme'    => [
-                    'type'  => Color::get_type(),
-                    'value' => Color::COLOR_1,
-                ],
+				'global' => [
+            		'default' => Global_Colors::COLOR_PRIMARY,
+				],
                 'selectors' => [
                     '{{WRAPPER}} .post-title-wrapper h4.heading-tag' => 'color: {{VALUE}}',
                 ],

--- a/inc/widget/post-title.php
+++ b/inc/widget/post-title.php
@@ -142,9 +142,9 @@ class Post_Title extends Base{
             [
                 'label'     => __( 'Color', 'ultraaddons' ),
                 'type'      => Controls_Manager::COLOR,
-				'global' => [
-            		'default' => Global_Colors::COLOR_PRIMARY,
-				],
+                'global' => [
+                    'default' => Global_Colors::COLOR_PRIMARY,
+                ],
                 'selectors' => [
                     '{{WRAPPER}} .post-title-wrapper h4.heading-tag' => 'color: {{VALUE}}',
                 ],


### PR DESCRIPTION
The plugin is using the limited **Schemes** mechanism that had been replaced with **Globals** in Elementor 3.0.0.

Ref: https://developers.elementor.com/docs/deprecations/complex-example/

You need to update all the "[schemes](https://github.com/search?q=repo%3Acodersaiful%2Fultraaddons-elementor-lite%20Scheme&type=code)" in the code.